### PR TITLE
context-aware tag groups

### DIFF
--- a/src/components/FastTaggerContent.tsx
+++ b/src/components/FastTaggerContent.tsx
@@ -19,14 +19,14 @@ interface FastTaggerContentState {
   showSettings?: boolean;
   tagGroups?: FastTaggerGroup[];
   tagGroupsToTags?: FastTaggerGroupTags[];
-  excludeIds?: Set<String>, 
+  excludeIds?: Set<String>;
 }
 
 class FastTaggerContent extends React.Component<FastTaggerContentProps, FastTaggerContentState> {
   constructor(props: FastTaggerContentProps) {
     super(props);
     this.state = {
-      excludeIds: props.excludeIds ? new Set(props.excludeIds) : undefined
+      excludeIds: props.excludeIds ? new Set(props.excludeIds) : undefined,
     };
   }
 
@@ -86,7 +86,7 @@ class FastTaggerContent extends React.Component<FastTaggerContentProps, FastTagg
       return false;
     }
   };
-  
+
   onSettingsClick = () => {
     this.setState({ showSettings: true });
   };
@@ -126,7 +126,7 @@ class FastTaggerContent extends React.Component<FastTaggerContentProps, FastTagg
     }
 
     return (
-      <>
+      <div className="fast-tagger-content">
         {this.maybeRenderSettingsDialog()}
         {!this.state.loading &&
           this.state.tagGroupsToTags
@@ -136,7 +136,12 @@ class FastTaggerContent extends React.Component<FastTaggerContentProps, FastTagg
                 (!groupEntry.group.conditionTagId || this.isTagSelected(groupEntry.group.conditionTagId))
             )
             .map((groupEntry) => (
-              <Card className="fast-tagger-card">
+              <Card
+                className={
+                  "fast-tagger-card fast-tagger-group " +
+                  (groupEntry.group?.contexts ? groupEntry.group?.contexts.join(" ") : "all")
+                }
+              >
                 <Card.Header>{groupEntry.group?.name}</Card.Header>
                 <Card.Body>
                   <ButtonGroup>
@@ -149,7 +154,7 @@ class FastTaggerContent extends React.Component<FastTaggerContentProps, FastTagg
                         <Button
                           variant="secondary"
                           size="sm"
-                          className={this.isTagSelected(tag.id) ? "btn-success" : ""}
+                          className={"fast-tagger-group-tag" + (this.isTagSelected(tag.id) ? " btn-success" : "")}
                           onClick={() => this.onTagClick(tag)}
                           disabled={this.isTagExcluded(tag.id)}
                         >
@@ -166,7 +171,7 @@ class FastTaggerContent extends React.Component<FastTaggerContentProps, FastTagg
             <Icon icon={faGear} /> Settings
           </Button>
         </div>
-      </>
+      </div>
     );
   }
 }

--- a/src/components/FastTaggerSettingsDialog.tsx
+++ b/src/components/FastTaggerSettingsDialog.tsx
@@ -111,8 +111,8 @@ class FastTaggerSettingsDialog extends React.Component<FastTaggerSettingsDialogP
     });
   };
 
-  onGroupChanged = (tagGroup: FastTaggerGroup, name?: string, conditionTagId?: string) => {
-    FastTaggerService.updateTagGroup(tagGroup, name, conditionTagId).then(() => {
+  onGroupChanged = (tagGroup: FastTaggerGroup, name?: string, conditionTagId?: string, contexts?: string[]) => {
+    FastTaggerService.updateTagGroup(tagGroup, name, conditionTagId, contexts).then(() => {
       this.loadTags();
     });
   };
@@ -237,7 +237,9 @@ class FastTaggerSettingsDialog extends React.Component<FastTaggerSettingsDialogP
                       onUp={() => this.onGroupUp(tagGroup)}
                       onDown={() => this.onGroupDown(tagGroup)}
                       onRemove={() => this.onGroupRemove(tagGroup)}
-                      onChanged={(name, conditionTagId) => this.onGroupChanged(tagGroup, name, conditionTagId)}
+                      onChanged={(name, conditionTagId, contexts) =>
+                        this.onGroupChanged(tagGroup, name, conditionTagId, contexts)
+                      }
                     />
                   </div>
                 ))}

--- a/src/services/FastTaggerService.ts
+++ b/src/services/FastTaggerService.ts
@@ -379,7 +379,12 @@ export async function removeTagGroup(group: FastTaggerGroup) {
   _finalzeTagGroups();
 }
 
-export async function updateTagGroup(group: FastTaggerGroup, name?: string, conditionTagId?: string) {
+export async function updateTagGroup(
+  group: FastTaggerGroup,
+  name?: string,
+  conditionTagId?: string,
+  contexts?: string[]
+) {
   await init();
 
   const idx = groups.findIndex((e) => e.id == group.id);
@@ -389,6 +394,7 @@ export async function updateTagGroup(group: FastTaggerGroup, name?: string, cond
 
   groups[idx].name = name;
   groups[idx].conditionTagId = conditionTagId;
+  groups[idx].contexts = contexts;
 }
 
 export async function moveTagGroupUp(group: FastTaggerGroup) {
@@ -507,6 +513,7 @@ export interface FastTaggerGroup {
   id?: string;
   name?: string;
   order: number;
+  contexts?: string[];
   conditionTagId?: string;
 }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -30,3 +30,55 @@
     }
   }
 }
+
+.fast-tagger-content {
+  .fast-tagger-group {
+    display: none;
+
+    &.all {
+      display: block;
+    }
+  }
+}
+
+.scene-tabs {
+  .fast-tagger-group.scene {
+    display: block;
+  }
+}
+
+.image-tabs {
+  .fast-tagger-group.image {
+    display: block;
+  }
+}
+
+#group-page {
+  .fast-tagger-group.group {
+    display: block;
+  }
+}
+
+.gallery-tabs {
+  .fast-tagger-group.gallery {
+    display: block;
+  }
+}
+
+#performer-page {
+  .fast-tagger-group.performer {
+    display: block;
+  }
+}
+
+#studio-page {
+  .fast-tagger-group.studio {
+    display: block;
+  }
+}
+
+#tag-page {
+  .fast-tagger-group.tag {
+    display: block;
+  }
+}


### PR DESCRIPTION
tag groups can be configured to only display in certain tagging contexts (like scenes, images, performers, tags, etc)