### PR TITLE
add missin UI dependency on communit scripts UI libarry

### DIFF
--- a/src/source.yml
+++ b/src/source.yml
@@ -1,7 +1,9 @@
 name: Fast Tagger
 description: "Fast tagging without searching for tags"
-version: 1.1.1
+version: 1.1.2
 ui:
+  requires:
+    - CommunityScriptsUILibrary
   javascript:
     - FastTagger.js
   css:


### PR DESCRIPTION
plugin yaml file did not declare dependency on community scripts ui library, leading to error when installed without it being present