### PR TITLE
Fix for deleted tag group condition tag error

### DIFF
--- a/src/components/FastTaggerTagGroupForn.tsx
+++ b/src/components/FastTaggerTagGroupForn.tsx
@@ -370,7 +370,9 @@ class FastTaggerTagGroupForm extends React.PureComponent<FastTaggerTagGroupFormP
               <div title="Show only if tagged with this tag">
                 <Icon icon={faQuestion} />
               </div>
-              <TagLink tag={FastTaggerService.getTag(this.state.conditionTagId)} linkType="details"></TagLink>
+              {FastTaggerService.getTag(this.state.conditionTagId) != undefined && (
+                <TagLink tag={FastTaggerService.getTag(this.state.conditionTagId)} linkType="details"></TagLink>
+              )}
             </div>
           )}
           {this.state.edit && (!this.state.tagId || this.state.conditionTagId) && (
@@ -407,7 +409,9 @@ class FastTaggerTagGroupForm extends React.PureComponent<FastTaggerTagGroupFormP
               <div title="Stored in this tag">
                 <Icon icon={faTag} />
               </div>
-              <TagLink tag={FastTaggerService.getTag(this.state.tagId)} linkType="details"></TagLink>
+              {FastTaggerService.getTag(this.state.tagId) != undefined && (
+                <TagLink tag={FastTaggerService.getTag(this.state.tagId)} linkType="details"></TagLink>
+              )}
             </div>
           )}
           {this.state.edit && !this.state.conditionTagId && (

--- a/src/services/FastTaggerService.ts
+++ b/src/services/FastTaggerService.ts
@@ -87,7 +87,7 @@ async function saveConfigCustomFields() {
   if (!customFieldsSupported) {
     return;
   }
-  
+
   const savedGroupTagIds: Set<string> = new Set([]);
 
   const promises = [];
@@ -184,7 +184,7 @@ async function saveGroupToCustomFields(group: FastTaggerGroup): Promise<string |
   if (!customFieldsSupported) {
     throw "custom fields are not supported";
   }
-  
+
   // not a group contitional on tag -> not persistable in tag
   var tagId;
   if (!group.conditionTagId && !group.tagId) {
@@ -587,6 +587,17 @@ async function loadTags() {
       const rightValue = (right.sort_name ? right.sort_name : "") + right.name;
       return leftValue.localeCompare(rightValue);
     });
+
+    for (const group of groups) {
+      // condition tag points to now unknown tag ID -> treat as unset
+      if (group.conditionTagId && !tagsById.get(group.conditionTagId)) {
+        group.conditionTagId = undefined;
+      }
+      // backing tag points to now unknown tag ID -> treat as unset
+      if (group.tagId && !tagsById.get(group.tagId)) {
+        group.tagId = undefined;
+      }
+    }
   });
 }
 
@@ -895,7 +906,7 @@ export async function importFromCustomFields() {
   if (!customFieldsSupported) {
     return;
   }
-  
+
   await clearConfigPlugin();
   clearState();
   await init();

--- a/src/source.yml
+++ b/src/source.yml
@@ -1,6 +1,6 @@
 name: Fast Tagger
 description: "Fast tagging without searching for tags"
-version: 1.5.2
+version: 1.5.3
 ui:
   requires:
     - CommunityScriptsUILibrary


### PR DESCRIPTION
tag settings dialog should no longer explode into error if group has conditional or backing tag set to nonexistant tag ID

closes #23